### PR TITLE
mobile workaround for `Send Feedback ❤️` button

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -13,8 +13,13 @@
     </a>
 
     <a href="https://www.buzzsprout.com/twilio/text_messages/2326928/open_sms" rel="noopener" target="_blank"
-      class="bg-white py-1 px-4 border border-gray-400 rounded-full hover:no-underline hover:scale-105 transition-transform h-[35px] ">
+      class="bg-white py-1 px-4 border border-gray-400 rounded-full hover:no-underline hover:scale-105 transition-transform h-[35px] hidden md:block">
       Send Feedback ❤️
+    </a>
+
+    <a href="https://www.buzzsprout.com/twilio/text_messages/2326928/open_sms" rel="noopener" target="_blank"
+      class="bg-white py-1 px-4 border border-gray-400 rounded-full hover:no-underline hover:scale-105 transition-transform h-[35px] inline md:hidden">
+      Feedback ❤️
     </a>
 
     <a target="_blank" rel="noopener me"


### PR DESCRIPTION
## Summary
This PR adds a mobile-only feedback button with a shorter text so the icons ok on a smaller screen!

On a smaller screen, the original button is hidden and the new button is displayed.

**Note:** We should probably rethink how to arrange the nav icons on a smaller screens. This is a workaround for now!

## Context
The button looks wonky on mobile:
<p align="center">
<img width=600 src="https://github.com/djangobrew/djangobrew.com/assets/6550256/d1eff9b1-015e-470f-87ad-8f03d82b07d0">
</p>

## Preview
https://github.com/djangobrew/djangobrew.com/assets/6550256/90d8e36b-fc29-4267-8444-baf58bdc5117


